### PR TITLE
updating README with correct link for PUB and SUB guide xively/xiPy#1

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -44,7 +44,7 @@ Usage
 
 This connects client to Xively. How to get Xively credentials? See `PUB and SUB with the Python library`_.
 
-.. _`PUB and SUB with the Python library`: http://developer.xively.com/tutorials/pub-and-sub-from-python
+.. _`PUB and SUB with the Python library`: https://developer.xively.com/docs/publish-and-subscribe-with-the-python-library
 
  Set connection finished callback
 ---------------------------------


### PR DESCRIPTION
Updating the link in the readme to point to the new docs location. Resolves #1 